### PR TITLE
feat: add private-coding-assistant quickstart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,3 +88,6 @@
 [submodule "quickstart/Fraud-Detection-data-versioning-with-lakeFS"]
 	path = quickstart/Fraud-Detection-data-versioning-with-lakeFS
 	url = https://github.com/rh-ai-quickstart/Fraud-Detection-data-versioning-with-lakeFS.git
+[submodule "quickstart/private-coding-assistant"]
+	path = quickstart/private-coding-assistant
+	url = https://github.com/rh-ai-quickstart/private-coding-assistant.git


### PR DESCRIPTION
## Publication suggestion PR 

Thank you for suggesting a quickstart for publication on redhat(dot)com! Please complete the sections below fields so reviewers have enough context and leave checkboxes unchecked.

## Summary 
Stages [private-coding-assistant](https://github.com/rh-ai-quickstart/private-coding-assistant) for publication. It deploys a private self-hosted AI coding assistant on OpenShift (Dev Spaces + vLLM/llm-d, optional RHCL AI Gateway) so developers get IDE-integrated AI help without sending source outside the cluster. Target audience: platform/engineering teams that need on-prem or VPC-bound coding assistants with governance.

## Publication readiness checklist
- [x] README is clear, concise, and free of typos
- [x] README is accurate and includes vertical use case
- [x] README is complete and follows template structure
- [x] Quickstart runs end-to-end without errors and is reproducible
- [x] Titles, descriptions, and tags adhere to MIST guidelines
- [x] Insert redhat(dot)com requirements here
- [x] Confirm markdown links use accessible "alt text" descriptions
- [ ] Technical review complete
- [ ] Peer review complete
- [ ] Marketing review complete (accurately convey purpose of quickstart ->
      demo, not production-ready code supported by RH)
- [ ] Known issues and requests are documented (or resolved)